### PR TITLE
feat: check if a scheduled task is `x` minutes late

### DIFF
--- a/.phpmd.xml
+++ b/.phpmd.xml
@@ -50,7 +50,7 @@
     </rule>
     <rule ref="rulesets/codesize.xml/NPathComplexity">
         <properties>
-            <property name="minimum" value="260" />
+            <property name="minimum" value="516" />
         </properties>
     </rule>
     <rule ref="rulesets/codesize.xml/TooManyPublicMethods">

--- a/Classes/Domain/Model/HealthcheckConfiguration.php
+++ b/Classes/Domain/Model/HealthcheckConfiguration.php
@@ -77,6 +77,13 @@ class HealthcheckConfiguration
     protected $enableAdditionalInfo = 0;
 
     /**
+     * A configuration for the scheduler probe. How many minutes of late execution time are tolerated.
+     *
+     * @var int
+     */
+    protected $schedulerMaxMinutesLate = 0;
+
+    /**
      * The configuration for the solr probe. How many index queue errors are tolerated.
      *
      * @var int
@@ -127,6 +134,9 @@ class HealthcheckConfiguration
                 }
                 if (isset($extConf['enableAdditionalInfo'])) {
                     $this->enableAdditionalInfo = intval($extConf['enableAdditionalInfo']);
+                }
+                if (isset($extConf['schedulerMaxMinutesLate'])) {
+                    $this->schedulerMaxMinutesLate = intval($extConf['schedulerMaxMinutesLate']);
                 }
                 if (isset($extConf['solrMaxErrorCount'])) {
                     $this->solrMaxErrorCount = intval($extConf['solrMaxErrorCount']);
@@ -225,6 +235,16 @@ class HealthcheckConfiguration
     public function getOutputs(): array
     {
         return $this->outputs;
+    }
+
+    /**
+     * Returns the configured solr max index queue item error counter.
+     *
+     * @return int Max allowed solr index queue errors
+     */
+    public function getSchedulerMaxMinutesLate(): int
+    {
+        return $this->schedulerMaxMinutesLate;
     }
 
     /**

--- a/Classes/Probe/SchedulerProbe.php
+++ b/Classes/Probe/SchedulerProbe.php
@@ -7,6 +7,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use WorldDirect\Healthcheck\Probe\ProbeBase;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use WorldDirect\Healthcheck\Domain\Model\HealthcheckConfiguration;
 use WorldDirect\Healthcheck\Utility\HealthcheckUtility;
 
 /*
@@ -73,7 +74,11 @@ class SchedulerProbe extends ProbeBase implements ProbeInterface
                 ->executeQuery()
                 ->fetchAllAssociative();
 
+            /** @var HealthcheckConfiguration */
+            $healthcheckConfiguration = GeneralUtility::makeInstance(HealthcheckConfiguration::class);
+
             // Step through all tasks and check if they have "lastexecution_failure" set
+            // also check if the next execution is 10 minutes late
             foreach ($tasks as $task) {
                 if (isset($task['lastexecution_failure']) && $task['lastexecution_failure'] != '') {
                     // Error message
@@ -81,6 +86,16 @@ class SchedulerProbe extends ProbeBase implements ProbeInterface
                         sprintf(
                             $this->langService->sL(HealthcheckUtility::LANG_PREFIX . 'probe.scheduler.error.executionFailure'),
                             strval($task['uid']),
+                            strval($task['description'])
+                        )
+                    );
+                } else if (isset($task['nextexecution']) && is_int($task['nextexecution']) && (time() - $task['nextexecution']) > $healthcheckConfiguration->getSchedulerMaxMinutesLate() * 60) {
+                    // Error message
+                    $this->result->addErrorMessage(
+                        sprintf(
+                            $this->langService->sL(HealthcheckUtility::LANG_PREFIX . 'probe.scheduler.error.executionLate'),
+                            strval($task['uid']),
+                            strval($healthcheckConfiguration->getSchedulerMaxMinutesLate()),
                             strval($task['description'])
                         )
                     );

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -63,6 +63,9 @@
             <trans-unit id="probe.scheduler.error.executionFailure">
                 <source><![CDATA[The task with the uid <span class="badge bg-primary">%s</span> has failures. <span class="badge bg-secondary">Description</span> "%s"]]></source>
             </trans-unit>
+            <trans-unit id="probe.scheduler.error.executionLate">
+                <source><![CDATA[The task with the uid <span class="badge bg-primary">%s</span> is <span class="badge bg-secondary">%s</span> or more minutes late. <span class="badge bg-secondary">Description</span> "%s"]]></source>
+            </trans-unit>
             <trans-unit id="probe.scheduler.notasks">
                 <source>There are no scheduled tasks configured.</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -22,6 +22,9 @@
             <trans-unit id="extConf.enableAdditionalInfo.description">
                 <source>Enable additional informations:Like the current IP address, current date, ...</source>
             </trans-unit>
+            <trans-unit id="extConf.probes.scheduler.maxMinutesLate">
+                <source>Maximum allowed late execution in minutes (if late execution time exceeds this, Healthcheck fails)</source>
+            </trans-unit>
             <trans-unit id="extConf.probes.solr.maxErrorCount">
                 <source>Maximum allowed solr index queue item error count (if more errors than this, Healthcheck fails)</source
             ></trans-unit>

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -17,5 +17,8 @@ enableBuildinfo = 1
 # cat=features/enable/6; type=boolean; label=LLL:EXT:healthcheck/Resources/Private/Language/locallang_db.xlf:extConf.enableAdditionalInfo.description
 enableAdditionalInfo = 1
 
+# cat=features/enable/7; type=int; label=LLL:EXT:healthcheck/Resources/Private/Language/locallang_db.xlf:extConf.probes.solr.maxMinutesLate
+schedulerMaxMinutesLate = 10
+
 # cat=features/enable/solrMaxErrorCount; type=int; label=LLL:EXT:healthcheck/Resources/Private/Language/locallang_db.xlf:extConf.probes.solr.maxErrorCount
 solrMaxErrorCount = 50


### PR DESCRIPTION
Example:

![image](https://github.com/world-direct-cms/healthcheck/assets/157011399/8d014594-c0e5-4dee-8228-a388847ea8ef)
